### PR TITLE
Readme and package fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,19 @@ Common prefixes for "role-based" email addresses that represent a position, job,
 
 Please contribute. Just keep them in alphabetical order please (the "natural" order that calling `sort()` on the array would return).
 
+## 📦 Publishing (for maintainers)
+
+To publish a new version:
+
+1. Bump the version:
+   `npm version <patch|minor|major>`
+2. Update `CHANGELOG.md` and amend the commit:
+   `git add CHANGELOG.md && git commit --amend --no-edit`
+3. Push with tags:
+   `git push --follow-tags`
+4. Publish to npm:
+   `npm publish --access public`
+
 ## License
 
 MIT

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "role-based-email-addresses",
       "version": "3.0.0",
       "license": "MIT",
       "devDependencies": {


### PR DESCRIPTION
Resyncs the package-lock file. Previously it was likely built with an older version of npm.

Adds publish instructions for maintainers.